### PR TITLE
Refactor router to use path params

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,23 @@
+import { Router, Route, Switch } from "wouter"
+import { EpubLibrary } from "@/components/reader/EpubLibrary"
 import EpubPage from "@/pages/EpubPage"
 
-const App = () => <EpubPage />
+const App = () => {
+  return (
+    <Router>
+      <Switch>
+        <Route path="/">
+          <EpubLibrary />
+        </Route>
+        <Route path="/book/:id">
+          <EpubPage />
+        </Route>
+        <Route>
+          <div className="p-4">404 - Not Found</div>
+        </Route>
+      </Switch>
+    </Router>
+  )
+}
 
 export default App

--- a/src/components/reader/EpubLibrary.tsx
+++ b/src/components/reader/EpubLibrary.tsx
@@ -10,7 +10,7 @@ export const EpubLibrary = () => {
   const [, navigate] = useLocation()
 
   const handleBookClick = (id: number) => {
-    navigate(`/?book=${id}`)
+    navigate(`/book/${id}`)
   }
 
   const handleDeleteClick = (e: React.MouseEvent, id: number) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from "react"
-import { Router } from "wouter"
 import { createRoot } from "react-dom/client"
 import "./index.css"
 import App from "./App.tsx"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <Router>
-      <App />
-    </Router>
+    <App />
   </StrictMode>,
 )

--- a/src/pages/EpubPage.tsx
+++ b/src/pages/EpubPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react"
 import AppFrame from "../components/Frame/AppFrame"
 import { useEpubStore } from "@/store/epubStore"
-import { useSearchParams } from "wouter"
+import { useParams } from "wouter"
 
 import { EpubLibrary } from "@/components/reader/EpubLibrary"
 import { EpubReader } from "@/components/reader/EpubReader"
@@ -9,20 +9,20 @@ import { CmdK } from "@/components/reader/CmdK"
 
 export default function EpubPage() {
   const { reader: book, loadBook, refreshAvailableBooks, closeBook } = useEpubStore()
-  const [params] = useSearchParams()
+  const { id } = useParams<{ id: string }>()
 
   useEffect(() => {
     document.title = "EPUB Reader"
   }, [])
 
   useEffect(() => {
-    const id = parseInt(params.get("book") ?? "")
-    if (!isNaN(id)) {
-      loadBook(id)
+    const bookId = Number(id)
+    if (!isNaN(bookId)) {
+      loadBook(bookId)
     } else {
       closeBook()
     }
-  }, [params, loadBook])
+  }, [id, loadBook, closeBook])
 
   useEffect(() => {
     refreshAvailableBooks()


### PR DESCRIPTION
## Summary
- move routing into `App` using wouter Router/Switch/Route
- load book id from URL params in `EpubPage`
- navigate to `/book/{id}` instead of query string
- remove Router wrapper from `main.tsx`

## Testing
- `npm run lint`
- `npx vitest run` *(fails: Cannot find package 'fake-indexeddb/auto')*